### PR TITLE
Missing setTotalCount on $searchResults object in getList method

### DIFF
--- a/app/code/Magento/Vault/Model/PaymentTokenRepository.php
+++ b/app/code/Magento/Vault/Model/PaymentTokenRepository.php
@@ -99,7 +99,7 @@ class PaymentTokenRepository implements PaymentTokenRepositoryInterface
         $searchResults = $this->searchResultsFactory->create();
         $searchResults->setSearchCriteria($searchCriteria);
         $searchResults->setItems($collection->getItems());
-
+        $searchResults->setTotalCount($collection->getSize());
         return $searchResults;
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
added setTotalCount($collection->getSize()) on $searchResults return object in getList() method (as every other similar has)

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
$entities = $this->paymentTokenRepository->getList(
	$this->searchCriteriaBuilder
		->addFilter('gateway_token', $token)
		->create()
);
printf($entities->getTotalCount()); // will print null

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
