### PR TITLE
Missing "RESTRICT" value in foreign constraint

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/constraints/foreign.xsd
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/constraints/foreign.xsd
@@ -33,6 +33,7 @@
             <xs:enumeration value="CASCADE" />
             <xs:enumeration value="SET NULL" />
             <xs:enumeration value="NO ACTION" />
+            <xs:enumeration value="RESTRICT" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
### Description (*)
Added missing "RESTRICT" value to declarative schema foreign constraint

### Fixed Issues (if relevant)
1. magento/magento2#27072: Missing "RESTRICT" value to declarative schema foreign constraint

### Manual testing scenarios (*)
1. Create a table with a customer_id column that references customer_entity.entity_id column, and you want that Customers cannot be deleted if there are associated records in your table.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
